### PR TITLE
feat: add functionality to fetch the title of a webpage when creating a URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,20 @@ module github.com/1tn-pw/short-service
 go 1.22
 
 require (
-	github.com/1tn-pw/protobufs v0.1.0
+	github.com/1tn-pw/protobufs v0.1.2-0.20240228194549-fcfbbe8efbdf
 	github.com/bugfixes/go-bugfixes v0.10.0
 	github.com/keloran/go-config v0.4.2
 	github.com/keloran/go-healthcheck v1.2.2
+	github.com/stretchr/testify v1.8.4
 	go.mongodb.org/mongo-driver v1.14.0
+	go.uber.org/mock v0.4.0
 	google.golang.org/grpc v1.62.0
 )
 
 require (
 	github.com/caarlos0/env/v8 v8.0.0 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-ping/ping v1.1.0 // indirect
@@ -32,20 +35,25 @@ require (
 	github.com/hashicorp/vault/api v1.12.0 // indirect
 	github.com/keloran/vault-helper v0.8.2 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
+	github.com/matryer/moq v0.3.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	golang.org/x/crypto v0.19.0 // indirect
+	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/tools v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/1tn-pw/protobufs v0.1.0 h1:fZ9uiKoxEUx/WnAgd+j4Fs/WEJJle/LW2KgYYBlQdeA=
 github.com/1tn-pw/protobufs v0.1.0/go.mod h1:i/OFm1UMBaDvvhizteZfIPbfMrFEvIjU5WS2PpCYfCg=
+github.com/1tn-pw/protobufs v0.1.1 h1:b6SwRo0GrJlSOOXMgCWKtu85lBWgLSSeGzje0DjHSGM=
+github.com/1tn-pw/protobufs v0.1.1/go.mod h1:i/OFm1UMBaDvvhizteZfIPbfMrFEvIjU5WS2PpCYfCg=
+github.com/1tn-pw/protobufs v0.1.2-0.20240228194549-fcfbbe8efbdf h1:HZBz1TeVZQtJzpeiC3dLYq92pMKjWO3OMn/70FqeiRo=
+github.com/1tn-pw/protobufs v0.1.2-0.20240228194549-fcfbbe8efbdf/go.mod h1:i/OFm1UMBaDvvhizteZfIPbfMrFEvIjU5WS2PpCYfCg=
 github.com/bugfixes/go-bugfixes v0.10.0 h1:zZFRIOTzir5WAXC7ooZvQ0tTV3rDX5dNjtH9Sc10Z9k=
 github.com/bugfixes/go-bugfixes v0.10.0/go.mod h1:IXxsOIHAu9XJGVYvfhBAKmDj3zPPI3mBcrW9ESehpJk=
 github.com/caarlos0/env/v8 v8.0.0 h1:POhxHhSpuxrLMIdvTGARuZqR4Jjm8AYmoi/JKlcScs0=
@@ -63,6 +67,8 @@ github.com/keloran/vault-helper v0.8.2 h1:Nmsb3XAhuaLQRv+LirOTSjdv6WcJuqNK+7xnOL
 github.com/keloran/vault-helper v0.8.2/go.mod h1:JZ/puuBd4+dWYZOeVEA7SgzbQS2VyYJibWte6q1h8Mk=
 github.com/klauspost/compress v1.17.6 h1:60eq2E/jlfwQXtvZEeBUYADs+BwKBWURIY+Gj2eRGjI=
 github.com/klauspost/compress v1.17.6/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/matryer/moq v0.3.4 h1:czCFIos9rI2tyOehN9ktc/6bQ76N9J4xQ2n3dk063ac=
+github.com/matryer/moq v0.3.4/go.mod h1:wqm9QObyoMuUtH81zFfs3EK6mXEcByy+TjvSROOXJ2U=
 github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -95,6 +101,8 @@ github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -102,6 +110,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -136,6 +146,8 @@ golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240213162025-012b6fc9bca9 h1:hZB7eLIaYlW9qXRfCq/qDaPdbeY3757uARz5Vvfv+cY=
@@ -146,6 +158,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/short/grpc.go
+++ b/internal/short/grpc.go
@@ -48,6 +48,7 @@ func (s *Server) GetURL(ctx context.Context, in *pb.GetURLRequest) (*pb.GetURLRe
 	}
 
 	return &pb.GetURLResponse{
-		Url: resp,
+		Url:   resp.LongURL,
+		Title: resp.Title,
 	}, nil
 }

--- a/internal/short/grpc_test.go
+++ b/internal/short/grpc_test.go
@@ -1,0 +1,50 @@
+package short
+
+import (
+	"context"
+	pb "github.com/1tn-pw/protobufs/generated/short_service/v1"
+	"testing"
+)
+
+// Initialize our server to be available for all tests
+var server = Server{}
+
+// TestCreateURL tests the CreateURL method of our grpc server
+func TestCreateURL(t *testing.T) {
+	// Define the input and expected outcome
+	input := &pb.CreateURLRequest{Url: "testUrl"}
+	expected := "expectedShortUrl"
+
+	// Call the function with our input
+	response, err := server.CreateURL(context.Background(), input)
+
+	// Perform test for error
+	if err != nil {
+		t.Errorf("Error was expected to be nil but got %v", err)
+	}
+
+	// Perform test for returned result
+	if response.ShortUrl != expected {
+		t.Errorf("Expected %s but got %s", expected, response.ShortUrl)
+	}
+}
+
+// TestGetURL tests the GetURL method of our grpc server
+func TestGetURL(t *testing.T) {
+	// Define the input and expected outcome
+	input := &pb.GetURLRequest{ShortUrl: "testShortUrl"}
+	expected := "expectedUrl"
+
+	// Call the function with our input
+	response, err := server.GetURL(context.Background(), input)
+
+	// Perform test for error
+	if err != nil {
+		t.Errorf("Error was expected to be nil but got %v", err)
+	}
+
+	// Perform test for returned result
+	if response.Url != expected {
+		t.Errorf("Expected %s but got %s", expected, response.Url)
+	}
+}

--- a/internal/short/mongo_test.go
+++ b/internal/short/mongo_test.go
@@ -1,0 +1,51 @@
+package short
+
+import (
+	"context"
+	"github.com/bugfixes/go-bugfixes/logs"
+	mungo "github.com/keloran/go-config/mongo"
+)
+
+type MockMongoOperations struct {
+	shouldError bool
+	exists      bool
+}
+
+func (m *MockMongoOperations) GetMongoClient(ctx context.Context, cfg mungo.Mongo) error {
+	if m.shouldError {
+		return logs.Errorf("GetMongoClient: error")
+	}
+
+	return nil
+}
+
+func (m *MockMongoOperations) Disconnect(ctx context.Context) error {
+	if m.shouldError {
+		return logs.Errorf("Disconnect: error")
+	}
+
+	return nil
+}
+
+func (m *MockMongoOperations) InsertOne(ctx context.Context, document interface{}) (interface{}, error) {
+	if m.shouldError {
+		return nil, logs.Errorf("InsertOne: error")
+	}
+
+	return "123", nil
+}
+
+func (m *MockMongoOperations) FindOne(ctx context.Context, filter interface{}) (interface{}, error) {
+	if m.shouldError {
+		return nil, logs.Errorf("FindOne: error")
+	}
+	if m.exists {
+		return &DocShort{
+			LongURL:  "https://example.com",
+			ShortURL: "https://short.example.com",
+			Title:    "Example",
+		}, nil
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
The changes in this commit add the ability to fetch the title of a webpage when creating a URL. This is done by adding a new function `fetchTitle` that makes an HTTP GET request to the provided URL and parses the HTML response to extract the title. The fetched title is then stored in the `Title` field of the `DocShort` struct. This allows users to have a better understanding of the content of the webpage associated with a shortened URL.